### PR TITLE
Middleware fails to stop when monitor is absent

### DIFF
--- a/microcache_test.go
+++ b/microcache_test.go
@@ -375,8 +375,7 @@ func TestStop(t *testing.T) {
 	}()
 	select {
 	case <-time.After(100 * time.Millisecond):
-		t.Log("Middleware failed to stop")
-		t.Fail()
+		t.Fatal("Middleware failed to stop")
 	case <-done:
 		return
 	}

--- a/microcache_test.go
+++ b/microcache_test.go
@@ -351,7 +351,6 @@ func TestNoWriteHeader(t *testing.T) {
 		Monitor: testMonitor,
 		Driver:  NewDriverLRU(10),
 	})
-	cache.Start()
 	handler := cache.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
 	}))
@@ -364,6 +363,23 @@ func TestNoWriteHeader(t *testing.T) {
 		t.Fail()
 	}
 	cache.Stop()
+}
+
+// Stop
+func TestStop(t *testing.T) {
+	cache := New(Config{})
+	done := make(chan bool)
+	go func() {
+		cache.Stop()
+		done <- true
+	}()
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Log("Middleware failed to stop")
+		t.Fail()
+	case <-done:
+		return
+	}
 }
 
 // --- helper funcs ---


### PR DESCRIPTION
Stumbled across this while testing something else.

`Stop()` hangs when no monitor is provided