### PR TITLE
Improved test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ Write throughput:                   896791 bytes/sec
 Test time:                              10 sec
 ```
 
-## Release
+## Release Status
 
-Tests have been written to confirm the correct behavior of this cache.
+API is stable. 100% test coverage.
 
 At least one large scale deployment of this library has been running in production
 on a high volume internet facing API at an Alexa Top 500 global website for over a year.

--- a/compressor_test.go
+++ b/compressor_test.go
@@ -1,0 +1,36 @@
+package microcache
+
+import (
+	"bytes"
+	"testing"
+)
+
+var zipTest = []byte(`{"firstName":"John","lastName":"Smith","isAlive":true,"age":27,"address":{"streetAddress":"21 2nd Street","city":"New York","state":"NY","postalCode":"10021-3100"},"phoneNumbers":[{"type":"home","number":"212 555-1234"},{"type":"office","number":"646 555-4567"},{"type":"mobile","number":"123 456-7890"}],"children":[],"spouse":null}`)
+
+// CompressorGzip
+func TestCompressorGzip(t *testing.T) {
+	res := Response{body: zipTest}
+	c := CompressorGzip{}
+	crRes := c.Compress(res)
+	if len(res.body) <= len(crRes.body) {
+		t.Fatal("No Compression in Gzip")
+	}
+	exRes := c.Expand(crRes)
+	if !bytes.Equal(res.body, exRes.body) {
+		t.Fatal("Expanded compression does not match in Gzip")
+	}
+}
+
+// CompressorSnappy
+func TestCompressorSnappy(t *testing.T) {
+	res := Response{body: zipTest}
+	c := CompressorSnappy{}
+	crRes := c.Compress(res)
+	if len(res.body) <= len(crRes.body) {
+		t.Fatal("No Compression in Gzip")
+	}
+	exRes := c.Expand(crRes)
+	if !bytes.Equal(res.body, exRes.body) {
+		t.Fatal("Expanded compression does not match in Gzip")
+	}
+}

--- a/driver_test.go
+++ b/driver_test.go
@@ -8,7 +8,7 @@ import (
 // Remove should work as expected
 func TestRemove(t *testing.T) {
 	var testDriver = func(name string, d Driver) {
-		cache := New(Config{Driver:  d})
+		cache := New(Config{Driver: d})
 		defer cache.Stop()
 		handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
 		batchGet(handler, []string{
@@ -33,7 +33,7 @@ func TestRemove(t *testing.T) {
 // Empty init should not fatal
 func TestEmptyInit(t *testing.T) {
 	var testDriver = func(name string, d Driver) {
-		cache := New(Config{Driver:  d})
+		cache := New(Config{Driver: d})
 		defer cache.Stop()
 		handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
 		batchGet(handler, []string{

--- a/driver_test.go
+++ b/driver_test.go
@@ -1,0 +1,49 @@
+package microcache
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Remove should work as expected
+func TestRemove(t *testing.T) {
+	var testDriver = func(name string, d Driver) {
+		cache := New(Config{Driver:  d})
+		defer cache.Stop()
+		handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+		batchGet(handler, []string{
+			"/",
+		})
+		if d.GetSize() != 1 {
+			t.Fatalf("%s Driver reports inaccurate length", name)
+		}
+		r, _ := http.NewRequest("GET", "/", nil)
+		reqHash := getRequestHash(cache, r)
+		reqOpts := buildRequestOpts(cache, Response{}, r)
+		objHash := reqOpts.getObjectHash(reqHash, r)
+		d.Remove(objHash)
+		if d.GetSize() != 0 {
+			t.Fatalf("%s Driver cannot delete items", name)
+		}
+	}
+	testDriver("ARC", NewDriverARC(10))
+	testDriver("LRU", NewDriverLRU(10))
+}
+
+// Empty init should not fatal
+func TestEmptyInit(t *testing.T) {
+	var testDriver = func(name string, d Driver) {
+		cache := New(Config{Driver:  d})
+		defer cache.Stop()
+		handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+		batchGet(handler, []string{
+			"/a",
+			"/b",
+		})
+		if d.GetSize() != 1 {
+			t.Fatalf("%s Driver should have length 1", name)
+		}
+	}
+	testDriver("ARC", NewDriverARC(0))
+	testDriver("LRU", NewDriverLRU(0))
+}

--- a/microcache.go
+++ b/microcache.go
@@ -240,7 +240,7 @@ func (m *microcache) Middleware(h http.Handler) http.Handler {
 		}
 
 		// Non-cacheable request method passthrough and purge
-		if r.Method != "GET" && r.Method != "HEAD" {
+		if r.Method != "GET" && r.Method != "HEAD" && r.Method != "OPTIONS" {
 			if m.Monitor != nil {
 				m.Monitor.Miss()
 			}
@@ -248,7 +248,7 @@ func (m *microcache) Middleware(h http.Handler) http.Handler {
 				// HTTP spec requires caches to purge cached responses following
 				// successful unsafe request
 				ptw := passthroughWriter{w, 0}
-				h.ServeHTTP(ptw, r)
+				h.ServeHTTP(&ptw, r)
 				if ptw.status >= 200 && ptw.status < 400 {
 					m.Driver.Remove(objHash)
 				}

--- a/microcache.go
+++ b/microcache.go
@@ -134,7 +134,7 @@ type Config struct {
 }
 
 // New creates and returns a configured microcache instance
-func New(o Config) Microcache {
+func New(o Config) *microcache {
 	// Defaults
 	m := microcache{
 		Nocache:              o.Nocache,

--- a/microcache.go
+++ b/microcache.go
@@ -336,6 +336,10 @@ func (m *microcache) handleBackendResponse(
 		h.ServeHTTP(&beres, r)
 	}
 
+	if !beres.headerWritten {
+		beres.status = http.StatusOK
+	}
+
 	// Log Error
 	if beres.status >= 500 && m.Monitor != nil {
 		m.Monitor.Error()

--- a/microcache_test.go
+++ b/microcache_test.go
@@ -446,6 +446,25 @@ func TestWebsocketPassthrough(t *testing.T) {
 	}
 }
 
+// Nocache should pass through when triggered by header
+func TestNocacheHeader(t *testing.T) {
+	cache := New(Config{Driver: NewDriverLRU(10)})
+	defer cache.Stop()
+	var resSubstitutionOccurred bool
+	handler := cache.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("microcache-nocache", "1")
+		_, resSubstitutionOccurred = w.(*Response)
+	}))
+	batchGet(handler, []string{"/"})
+	if !resSubstitutionOccurred {
+		t.Fatal("Response substitution should have occurred")
+	}
+	batchGet(handler, []string{"/"})
+	if resSubstitutionOccurred {
+		t.Fatal("Response substitution should not have occurred")
+	}
+}
+
 // Stop
 func TestStop(t *testing.T) {
 	cache := New(Config{})

--- a/microcache_test.go
+++ b/microcache_test.go
@@ -125,6 +125,7 @@ func TestStaleWhileRevalidate(t *testing.T) {
 		StaleWhileRevalidate: 30 * time.Second,
 		Monitor:              testMonitor,
 		Driver:               NewDriverLRU(10),
+		Exposed:              true,
 	})
 	defer cache.Stop()
 	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
@@ -196,6 +197,7 @@ func TestStaleIfError(t *testing.T) {
 		Monitor:      testMonitor,
 		QueryIgnore:  []string{"fail"},
 		Driver:       NewDriverLRU(10),
+		Exposed:      true,
 	})
 	defer cache.Stop()
 	handler := cache.Middleware(http.HandlerFunc(failureHandler))

--- a/monitor_func.go
+++ b/monitor_func.go
@@ -6,7 +6,7 @@ import (
 )
 
 // MonitorFunc turns a function into a Monitor
-func MonitorFunc(interval time.Duration, logFunc func(Stats)) Monitor {
+func MonitorFunc(interval time.Duration, logFunc func(Stats)) *monitorFunc {
 	return &monitorFunc{
 		interval: interval,
 		logFunc:  logFunc,

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -9,7 +9,7 @@ import (
 func TestMonitor(t *testing.T) {
 	var hits int
 	var expected = 4
-	testMonitor := MonitorFunc(100 * time.Second, func(s Stats) {
+	testMonitor := MonitorFunc(100*time.Second, func(s Stats) {
 		hits = s.Hits
 	})
 	testMonitor.hits = int64(expected)

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -34,7 +34,7 @@ func TestMicrocacheCallsMonitor(t *testing.T) {
 	defer cache.Stop()
 	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
 	batchGet(handler, []string{"/"})
-	size := <- statChan
+	size := <-statChan
 	if size != 1 {
 		t.Fatal("Monitor was not called by microcache")
 	}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,6 +1,7 @@
 package microcache
 
 import (
+	"net/http"
 	"testing"
 	"time"
 )
@@ -16,5 +17,25 @@ func TestMonitor(t *testing.T) {
 	testMonitor.Log(Stats{})
 	if hits != expected {
 		t.Fatalf("Monitor not logging correctly (%d != %d)", hits, expected)
+	}
+}
+
+// Microcache calls monitor
+func TestMicrocacheCallsMonitor(t *testing.T) {
+	var statChan = make(chan int)
+	testMonitor := &monitorFunc{interval: 10 * time.Millisecond, logFunc: func(s Stats) {
+		statChan <- s.Size
+	}}
+	cache := New(Config{
+		TTL:     30 * time.Second,
+		Monitor: testMonitor,
+		Driver:  NewDriverLRU(10),
+	})
+	defer cache.Stop()
+	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+	batchGet(handler, []string{"/"})
+	size := <- statChan
+	if size != 1 {
+		t.Fatal("Monitor was not called by microcache")
 	}
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,0 +1,20 @@
+package microcache
+
+import (
+	"testing"
+	"time"
+)
+
+// Remove should work as expected
+func TestMonitor(t *testing.T) {
+	var hits int
+	var expected = 4
+	testMonitor := MonitorFunc(100 * time.Second, func(s Stats) {
+		hits = s.Hits
+	})
+	testMonitor.hits = int64(expected)
+	testMonitor.Log(Stats{})
+	if hits != expected {
+		t.Fatalf("Monitor not logging correctly (%d != %d)", hits, expected)
+	}
+}

--- a/request.go
+++ b/request.go
@@ -11,6 +11,9 @@ import (
 func getRequestHash(m *microcache, r *http.Request) string {
 	h := sha1.New()
 	h.Write([]byte(r.URL.Path))
+	for _, header := range m.Vary {
+		h.Write([]byte("&" + header + ":" + r.Header.Get(header)))
+	}
 	if m.HashQuery {
 		if m.QueryIgnore != nil {
 			for key, values := range r.URL.Query() {
@@ -24,9 +27,6 @@ func getRequestHash(m *microcache, r *http.Request) string {
 		} else {
 			h.Write([]byte(r.URL.RawQuery))
 		}
-	}
-	for _, header := range m.Vary {
-		h.Write([]byte(header + r.Header.Get(header)))
 	}
 	return string(h.Sum(nil))
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,55 @@
+package microcache
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// buildRequestOpts detects response headers appropriately
+func TestBuildRequestOpts(t *testing.T) {
+	var i = 0
+	r, _ := http.NewRequest("GET", "/", nil)
+	type tc struct {
+		hdr string
+		val string
+		exp RequestOpts
+	}
+	var runCases = func(m *microcache, cases []tc) {
+		for _, c := range cases {
+			res := Response{header: http.Header{}}
+			res.Header().Set(c.hdr, c.val)
+			reqOpts := buildRequestOpts(m, res, r)
+			reqOpts.found = false
+			if !reflect.DeepEqual(reqOpts, c.exp) {
+				t.Fatalf("Mismatch in case %d\n%#v\n%#v", i + 1, reqOpts, c.exp)
+			}
+			i++
+		}
+	}
+	runCases(New(Config{}), []tc {
+		{"microcache-nocache", "1", RequestOpts{nocache: true}},
+		{"microcache-ttl", "10", RequestOpts{ttl: time.Duration(10 * time.Second)}},
+		{"microcache-stale-if-error", "10", RequestOpts{staleIfError: time.Duration(10 * time.Second)}},
+		{"microcache-stale-while-revalidate", "10", RequestOpts{staleWhileRevalidate: time.Duration(10 * time.Second)}},
+		{"microcache-collapsed-fowarding", "1", RequestOpts{collapsedForwarding: true}},
+		{"microcache-stale-recache", "1", RequestOpts{staleRecache: true}},
+		{"Microcache-Vary-Query", "a", RequestOpts{varyQuery: []string{"a"}}},
+	})
+	runCases(New(Config{Nocache: true}), []tc {
+		{"microcache-cache", "1", RequestOpts{nocache: false}},
+	})
+	runCases(New(Config{CollapsedForwarding: true}), []tc {
+		{"microcache-no-collapsed-fowarding", "1", RequestOpts{collapsedForwarding: false}},
+	})
+	runCases(New(Config{StaleRecache: true}), []tc {
+		{"microcache-no-stale-recache", "1", RequestOpts{staleRecache: false}},
+	})
+	runCases(New(Config{Vary: []string{"a"}}), []tc {
+		{"Microcache-Vary", "b", RequestOpts{vary: []string{"a", "b"}}},
+	})
+	runCases(New(Config{Vary: []string{"a"}}), []tc {
+		{"Vary", "b", RequestOpts{vary: []string{"a", "b"}}},
+	})
+}

--- a/request_test.go
+++ b/request_test.go
@@ -23,12 +23,12 @@ func TestBuildRequestOpts(t *testing.T) {
 			reqOpts := buildRequestOpts(m, res, r)
 			reqOpts.found = false
 			if !reflect.DeepEqual(reqOpts, c.exp) {
-				t.Fatalf("Mismatch in case %d\n%#v\n%#v", i + 1, reqOpts, c.exp)
+				t.Fatalf("Mismatch in case %d\n%#v\n%#v", i+1, reqOpts, c.exp)
 			}
 			i++
 		}
 	}
-	runCases(New(Config{}), []tc {
+	runCases(New(Config{}), []tc{
 		{"microcache-nocache", "1", RequestOpts{nocache: true}},
 		{"microcache-ttl", "10", RequestOpts{ttl: time.Duration(10 * time.Second)}},
 		{"microcache-stale-if-error", "10", RequestOpts{staleIfError: time.Duration(10 * time.Second)}},
@@ -37,19 +37,19 @@ func TestBuildRequestOpts(t *testing.T) {
 		{"microcache-stale-recache", "1", RequestOpts{staleRecache: true}},
 		{"Microcache-Vary-Query", "a", RequestOpts{varyQuery: []string{"a"}}},
 	})
-	runCases(New(Config{Nocache: true}), []tc {
+	runCases(New(Config{Nocache: true}), []tc{
 		{"microcache-cache", "1", RequestOpts{nocache: false}},
 	})
-	runCases(New(Config{CollapsedForwarding: true}), []tc {
+	runCases(New(Config{CollapsedForwarding: true}), []tc{
 		{"microcache-no-collapsed-fowarding", "1", RequestOpts{collapsedForwarding: false}},
 	})
-	runCases(New(Config{StaleRecache: true}), []tc {
+	runCases(New(Config{StaleRecache: true}), []tc{
 		{"microcache-no-stale-recache", "1", RequestOpts{staleRecache: false}},
 	})
-	runCases(New(Config{Vary: []string{"a"}}), []tc {
+	runCases(New(Config{Vary: []string{"a"}}), []tc{
 		{"Microcache-Vary", "b", RequestOpts{vary: []string{"a", "b"}}},
 	})
-	runCases(New(Config{Vary: []string{"a"}}), []tc {
+	runCases(New(Config{Vary: []string{"a"}}), []tc{
 		{"Vary", "b", RequestOpts{vary: []string{"a", "b"}}},
 	})
 }

--- a/response.go
+++ b/response.go
@@ -65,7 +65,7 @@ type passthroughWriter struct {
 	status int
 }
 
-func (w passthroughWriter) WriteHeader(code int) {
+func (w *passthroughWriter) WriteHeader(code int) {
 	w.status = code
 	w.ResponseWriter.WriteHeader(code)
 }

--- a/response.go
+++ b/response.go
@@ -19,9 +19,6 @@ type Response struct {
 }
 
 func (res *Response) Write(b []byte) (int, error) {
-	if !res.headerWritten {
-		res.WriteHeader(http.StatusOK)
-	}
 	res.body = append(res.body, b...)
 	return len(b), nil
 }


### PR DESCRIPTION
A few minor bug fixes, no meaningful interface changes

- Adds test coverage for untested code paths identified by [gocover.io](https://gocover.io/github.com/kevburnsjr/microcache)
- Constructor now returns [struct rather than interface](http://idiomaticgo.com/post/best-practice/accept-interfaces-return-structs/) for improved testability
- Moved assignment of default response status (200) to avoid weird behavior for downstream handlers that fail to set response status explicitly.

Raises test coverage from `69%` to `100%`