### PR TITLE
Add benchmark tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,31 +152,12 @@ snappy compress 48.836002ms  106,613 bytes (5.8x)
 zlib   expand 211.538416ms
 gzip   expand 220.011961ms
 snappy expand 26.973263ms
-
-> go run tools/compare_compression.go -f medium.json
-Original: 279,368 bytes of json
-zlib   compress 282.549098ms 19,825 bytes (14.1x)
-gzip   compress 275.961026ms 19,837 bytes (14.1x)
-snappy compress 16.452706ms  37,096 bytes (7.5x)
-zlib   expand 86.704103ms
-gzip   expand 81.188856ms
-snappy expand 10.557594ms
-
-> go run tools/compare_compression.go -f small.json
-Original: 53,129 bytes of json
-zlib   compress 73.204418ms 5,084 bytes (10.5x)
-gzip   compress 74.150401ms 5,096 bytes (10.4x)
-snappy compress 5.225558ms  8,412 bytes (6.3x)
-zlib   expand 18.764693ms
-gzip   expand 18.797717ms
-snappy expand 2.354814ms
 ```
 
 ## Benchmarks
 
-All benchmarks are lies. Running example code above on 5820k i7 @ 3.9Ghz DDR4
-
-GOMAXPROCS=2, 10KB response
+All benchmarks are lies. Running example code above on 5820k i7 @ 3.9Ghz DDR4.
+GOMAXPROCS=2, 10KB response.
 
 ```
 > gobench -u http://localhost/ -c 10 -t 10
@@ -192,9 +173,11 @@ Read throughput:                 410714568 bytes/sec
 Write throughput:                  3273453 bytes/sec
 Test time:                              10 sec
 ```
+
 The intent of this middleware is to serve cached content with minimal overhead. We could
 probably do some more gymnastics to reduce allocs but overall I'm quite satisfied with
-performance. It achieves the goal of reducing hit response timing to microseconds.
+performance. It achieves the goal of reducing hit response times to the order of microseconds.
+
 ```
 $ go test -bench=. -benchmem
 goos: linux

--- a/examples/basic/example.go
+++ b/examples/basic/example.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"log"
-	"math/rand"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/kevburnsjr/microcache"
@@ -13,22 +12,16 @@ import (
 type handler struct {
 }
 
+var body = bytes.Repeat([]byte("1234567890"), 1e3)
+
 // This example fills up to 1.2GB of memory, so at least 2.0GB of RAM is recommended
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Enable cache
 	w.Header().Set("microcache-cache", "1")
 
-	randn := rand.Intn(10) + 1
-
-	// Sleep between 10 and 100 ms
-	time.Sleep(time.Duration(randn*10) * time.Millisecond)
-
-	// Return a response body of random size between 10 and 100 kilobytes
-	// Requests per sec for cache hits is mostly dependent on response size
-	// This cache can saturate a gigabit network connection with cache hits
-	// containing response bodies as small as 10kb on a dual core 3.3 Ghz i7 VM
-	http.Error(w, strings.Repeat("1234567890", randn*1e3), 200)
+	// Return a 10 kilobyte response body
+	w.Write(body)
 }
 
 func logStats(stats microcache.Stats) {

--- a/microcache_bench_test.go
+++ b/microcache_bench_test.go
@@ -13,7 +13,7 @@ func BenchmarkHits(b *testing.B) {
 		Driver: NewDriverLRU(10),
 	})
 	defer cache.Stop()
-	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+	handler := cache.Middleware(http.HandlerFunc(successHandler))
 	r, _ := http.NewRequest("GET", "/", nil)
 	w := &noopWriter{http.Header{}}
 	b.ResetTimer()
@@ -28,7 +28,7 @@ func BenchmarkNocache(b *testing.B) {
 		Driver:  NewDriverLRU(10),
 	})
 	defer cache.Stop()
-	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+	handler := cache.Middleware(http.HandlerFunc(successHandler))
 	r, _ := http.NewRequest("GET", "/", nil)
 	w := &noopWriter{http.Header{}}
 	b.ResetTimer()
@@ -43,7 +43,7 @@ func BenchmarkMisses(b *testing.B) {
 		Driver: NewDriverLRU(10),
 	})
 	defer cache.Stop()
-	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+	handler := cache.Middleware(http.HandlerFunc(successHandler))
 	r, _ := http.NewRequest("GET", "/", nil)
 	w := &noopWriter{http.Header{}}
 	b.ResetTimer()
@@ -116,8 +116,10 @@ func (w *noopWriter) Header() http.Header {
 
 func (w *noopWriter) WriteHeader(code int) {}
 
-var json1k = `{"counts":[{"bucket":1569888000,"total":115,"unique":39},{"bucket":1569801600,"total":150,"unique":38},{"bucket":1569715200,"total":129,"unique":34},{"bucket":1569628800,"total":142,"unique":34},{"bucket":1569542400,"total":151,"unique":39},{"bucket":1569456000,"total":145,"unique":44},{"bucket":1569369600,"total":143,"unique":49},{"bucket":1569283200,"total":174,"unique":46},{"bucket":1569196800,"total":407,"unique":52},{"bucket":1569110400,"total":357,"unique":51},{"bucket":1569024000,"total":227,"unique":44},{"bucket":1568937600,"total":257,"unique":44},{"bucket":1568851200,"total":238,"unique":47},{"bucket":1568764800,"total":246,"unique":62}],"summary":{"total":2881,"unique":108}}`
+func successHandler(w http.ResponseWriter, r *http.Request) {}
+
+var json1k = []byte(`{"counts":[{"bucket":1569888000,"total":115,"unique":39},{"bucket":1569801600,"total":150,"unique":38},{"bucket":1569715200,"total":129,"unique":34},{"bucket":1569628800,"total":142,"unique":34},{"bucket":1569542400,"total":151,"unique":39},{"bucket":1569456000,"total":145,"unique":44},{"bucket":1569369600,"total":143,"unique":49},{"bucket":1569283200,"total":174,"unique":46},{"bucket":1569196800,"total":407,"unique":52},{"bucket":1569110400,"total":357,"unique":51},{"bucket":1569024000,"total":227,"unique":44},{"bucket":1568937600,"total":257,"unique":44},{"bucket":1568851200,"total":238,"unique":47},{"bucket":1568764800,"total":246,"unique":62}],"summary":{"total":2881,"unique":108}}`)
 
 func success1kHandler(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, json1k, 200)
+	w.Write(json1k)
 }

--- a/microcache_bench_test.go
+++ b/microcache_bench_test.go
@@ -1,0 +1,89 @@
+package microcache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func BenchmarkHits(b *testing.B) {
+	cache := New(Config{
+		TTL:    30 * time.Second,
+		Driver: NewDriverLRU(10),
+	})
+	defer cache.Stop()
+	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := &noopWriter{http.Header{}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkMisses(b *testing.B) {
+	cache := New(Config{
+		Nocache: true,
+		Driver:  NewDriverLRU(10),
+	})
+	defer cache.Stop()
+	handler := cache.Middleware(http.HandlerFunc(noopSuccessHandler))
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := &noopWriter{http.Header{}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkCompression1kHits(b *testing.B) {
+	cache := New(Config{
+		TTL:        30 * time.Second,
+		Driver:     NewDriverLRU(10),
+		Compressor: CompressorSnappy{},
+	})
+	defer cache.Stop()
+	handler := cache.Middleware(http.HandlerFunc(success1kHandler))
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := &noopWriter{http.Header{}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(w, r)
+	}
+}
+
+func BenchmarkCompression1kMisses(b *testing.B) {
+	cache := New(Config{
+		Nocache: true,
+		Driver:  NewDriverLRU(10),
+		Compressor: CompressorSnappy{},
+	})
+	defer cache.Stop()
+	handler := cache.Middleware(http.HandlerFunc(success1kHandler))
+	r, _ := http.NewRequest("GET", "/", nil)
+	w := &noopWriter{http.Header{}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(w, r)
+	}
+}
+
+type noopWriter struct {
+	header http.Header
+}
+
+func (w *noopWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (w *noopWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *noopWriter) WriteHeader(code int) {}
+
+var json1k = `{"counts":[{"bucket":1569888000,"total":115,"unique":39},{"bucket":1569801600,"total":150,"unique":38},{"bucket":1569715200,"total":129,"unique":34},{"bucket":1569628800,"total":142,"unique":34},{"bucket":1569542400,"total":151,"unique":39},{"bucket":1569456000,"total":145,"unique":44},{"bucket":1569369600,"total":143,"unique":49},{"bucket":1569283200,"total":174,"unique":46},{"bucket":1569196800,"total":407,"unique":52},{"bucket":1569110400,"total":357,"unique":51},{"bucket":1569024000,"total":227,"unique":44},{"bucket":1568937600,"total":257,"unique":44},{"bucket":1568851200,"total":238,"unique":47},{"bucket":1568764800,"total":246,"unique":62}],"summary":{"total":2881,"unique":108}}`
+
+func success1kHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, json1k, 200)
+}


### PR DESCRIPTION
```
$ go test -bench=. -benchmem
goos: linux
goarch: amd64
pkg: github.com/kevburnsjr/microcache
BenchmarkHits-12                            827476   1449 ns/op    678 B/op   14 allocs/op
BenchmarkNocache-12                        1968576    613 ns/op    312 B/op    6 allocs/op
BenchmarkMisses-12                          307652   3890 ns/op   1765 B/op   37 allocs/op
BenchmarkCompression1kHits-12               648564   1928 ns/op   1384 B/op   15 allocs/op
BenchmarkCompression1kNocache-12           1965351    611 ns/op    312 B/op    6 allocs/op
BenchmarkCompression1kMisses-12             232980   5119 ns/op   3365 B/op   39 allocs/op
BenchmarkParallelCompression1kHits-12      2525994    511 ns/op   1383 B/op   15 allocs/op
BenchmarkParallelCompression1kNocache-12   3876728    335 ns/op    312 B/op    6 allocs/op
BenchmarkParallelCompression1kMisses-12     666580   2226 ns/op   3326 B/op   38 allocs/op
PASS
ok      github.com/kevburnsjr/microcache        7.188s
```