### PR TITLE
Fix typo in collapsed forwarding header

### DIFF
--- a/request.go
+++ b/request.go
@@ -106,13 +106,13 @@ func buildRequestOpts(m *microcache, res Response, r *http.Request) RequestOpts 
 		req.staleWhileRevalidate = time.Duration(staleWhileRevalidateHdr) * time.Second
 	}
 
-	// w.Header().Set("microcache-collapsed-fowarding", "1")
-	if headers.Get("microcache-collapsed-fowarding") != "" {
+	// w.Header().Set("microcache-collapsed-forwarding", "1")
+	if headers.Get("microcache-collapsed-forwarding") != "" {
 		req.collapsedForwarding = true
 	}
 
-	// w.Header().Set("microcache-no-collapsed-fowarding", "1")
-	if headers.Get("microcache-no-collapsed-fowarding") != "" {
+	// w.Header().Set("microcache-no-collapsed-forwarding", "1")
+	if headers.Get("microcache-no-collapsed-forwarding") != "" {
 		req.collapsedForwarding = false
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -33,7 +33,7 @@ func TestBuildRequestOpts(t *testing.T) {
 		{"microcache-ttl", "10", RequestOpts{ttl: time.Duration(10 * time.Second)}},
 		{"microcache-stale-if-error", "10", RequestOpts{staleIfError: time.Duration(10 * time.Second)}},
 		{"microcache-stale-while-revalidate", "10", RequestOpts{staleWhileRevalidate: time.Duration(10 * time.Second)}},
-		{"microcache-collapsed-fowarding", "1", RequestOpts{collapsedForwarding: true}},
+		{"microcache-collapsed-forwarding", "1", RequestOpts{collapsedForwarding: true}},
 		{"microcache-stale-recache", "1", RequestOpts{staleRecache: true}},
 		{"Microcache-Vary-Query", "a", RequestOpts{varyQuery: []string{"a"}}},
 	})
@@ -41,7 +41,7 @@ func TestBuildRequestOpts(t *testing.T) {
 		{"microcache-cache", "1", RequestOpts{nocache: false}},
 	})
 	runCases(New(Config{CollapsedForwarding: true}), []tc{
-		{"microcache-no-collapsed-fowarding", "1", RequestOpts{collapsedForwarding: false}},
+		{"microcache-no-collapsed-forwarding", "1", RequestOpts{collapsedForwarding: false}},
 	})
 	runCases(New(Config{StaleRecache: true}), []tc{
 		{"microcache-no-stale-recache", "1", RequestOpts{staleRecache: false}},


### PR DESCRIPTION
`fowarding` -> `forwarding`

Tagging `1.1.0` after this is merged since it represents a change in behavior.