### PR TITLE
#16 Microcache sometimes reports errors

### DIFF
--- a/background_request.go
+++ b/background_request.go
@@ -1,0 +1,22 @@
+package microcache
+
+import (
+	"context"
+	"net/http"
+)
+
+// newBackgroundRequest clones a request for use in background object revalidation.
+// This prevents a closed foreground request context from prematurely cancelling
+// the background request context.
+func newBackgroundRequest(r *http.Request) *http.Request {
+	return r.Clone(bgContext{r.Context(), make(chan struct{})})
+}
+
+type bgContext struct {
+	context.Context
+	done chan struct{}
+}
+
+func (c bgContext) Done() <-chan struct{} {
+	return c.done
+}

--- a/microcache_test.go
+++ b/microcache_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -291,7 +292,7 @@ func TestTimeout(t *testing.T) {
 	}
 }
 
-// Request Context Cancel should not cause error
+// Request context cancellation should not cause error from TimeoutHandler
 func TestRequestContextCancel(t *testing.T) {
 	testMonitor := &monitorFunc{interval: 100 * time.Second, logFunc: func(Stats) {}}
 	cache := New(Config{


### PR DESCRIPTION
Failing test shows that canceling the original request causes the background request to error 503 due to behavior of `http.TimeoutHandler`